### PR TITLE
Start styling minimum dot size

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ indicator.attachToPager(pager, new ViewPagerAttacher());
 | spi_visibleDotCount | The maximum number of dots which will be visible at the same time. If pager has more pages than visible_dot_count, indicator will scroll to show extra dots. Must be odd number.  | ```5```          |
 | spi_visibleDotThreshold | The minimum number of dots which should be visible. If pager has less pages than visibleDotThreshold, no dots will be shown.  | ```2```          |
 | spi_looped | The mode for looped pagers support. You should make indicator looped if your custom pager is looped too. If pager has less items than ```spi_visibleDotCount```, indicator will work as usual; otherwise it will always be in infinite state. | ```false```|
+| spi_dotMinimumSize | The minimum dot size for the corner dots. This size is lower or equal to ```spi_dotSize``` and greater or equal to the internal calculation for the corner dots. | Internal calculation based on ```spi_dotSize```, ```spi_dotSelectedSize``` and ```spi_dotSpacing``` |
 
 ## TODO
 1. Some extreme customizations may work incorrect.

--- a/scrollingpagerindicator/src/main/java/ru/tinkoff/scrollingpagerindicator/ScrollingPagerIndicator.java
+++ b/scrollingpagerindicator/src/main/java/ru/tinkoff/scrollingpagerindicator/ScrollingPagerIndicator.java
@@ -21,6 +21,7 @@ public class ScrollingPagerIndicator extends View {
 
     private int infiniteDotCount;
 
+    private final int dotMinimumSize;
     private final int dotNormalSize;
     private final int dotSelectedSize;
     private final int spaceBetweenDotCenters;
@@ -68,6 +69,9 @@ public class ScrollingPagerIndicator extends View {
         selectedDotColor = attributes.getColor(R.styleable.ScrollingPagerIndicator_spi_dotSelectedColor, dotColor);
         dotNormalSize = attributes.getDimensionPixelSize(R.styleable.ScrollingPagerIndicator_spi_dotSize, 0);
         dotSelectedSize = attributes.getDimensionPixelSize(R.styleable.ScrollingPagerIndicator_spi_dotSelectedSize, 0);
+        int dotMinimumSize = attributes.getDimensionPixelSize(R.styleable.ScrollingPagerIndicator_spi_dotMinimumSize, -1);
+        this.dotMinimumSize = dotMinimumSize <= dotNormalSize ? dotMinimumSize : -1;
+
         spaceBetweenDotCenters = attributes.getDimensionPixelSize(R.styleable.ScrollingPagerIndicator_spi_dotSpacing, 0) + dotNormalSize;
         looped = attributes.getBoolean(R.styleable.ScrollingPagerIndicator_spi_looped, false);
         int visibleDotCount = attributes.getInt(R.styleable.ScrollingPagerIndicator_spi_visibleDotCount, 0);
@@ -432,12 +436,16 @@ public class ScrollingPagerIndicator extends View {
 
                     if (dot - visibleFramePosition < currentScaleDistance) {
                         float calculatedDiameter = diameter * (dot - visibleFramePosition) / currentScaleDistance;
-                        if (calculatedDiameter < diameter) {
+                        if (calculatedDiameter <= dotMinimumSize) {
+                            diameter = dotMinimumSize;
+                        } else if (calculatedDiameter < diameter) {
                             diameter = calculatedDiameter;
                         }
                     } else if (dot - visibleFramePosition > canvas.getWidth() - currentScaleDistance) {
                         float calculatedDiameter = diameter * (-dot + visibleFramePosition + canvas.getWidth()) / currentScaleDistance;
-                        if (calculatedDiameter < diameter) {
+                        if (calculatedDiameter <= dotMinimumSize) {
+                            diameter = dotMinimumSize;
+                        } else if (calculatedDiameter < diameter) {
                             diameter = calculatedDiameter;
                         }
                     }

--- a/scrollingpagerindicator/src/main/res/values/attrs.xml
+++ b/scrollingpagerindicator/src/main/res/values/attrs.xml
@@ -5,6 +5,7 @@
         <attr name="spi_dotSelectedColor" format="color" />
         <attr name="spi_dotSize" format="dimension" />
         <attr name="spi_dotSelectedSize" format="dimension" />
+        <attr name="spi_dotMinimumSize" format="dimension" />
         <attr name="spi_dotSpacing" format="dimension" />
         <attr name="spi_visibleDotCount" format="integer" />
         <attr name="spi_visibleDotThreshold" format="integer" />


### PR DESCRIPTION
With this PR we are able to define the minimum size of the dots in corners.
We can use the attribute spi_dotMinimumSize. 

-If the attribute is not defined, then the indicator will work as used to. 
-If we set the attribute then the minimum size will be defined by it.
-If the attribute is smaller than the internal calculation, then the indicator will work as used to.
-If the attribute defines a size bigger than the normal dot size, then the indicator will fall back to its previous behavior. (Aka will calculate the minimum size by itself based on the visible space).